### PR TITLE
Deploy documentation to GitHub Pages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+Changelog
+---------
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+Checklist
+---------
+
+- [ ] Test
+- [ ] Self-review
+- [ ] Documentation

--- a/.github/workflows/documentation-ci-cd.yml
+++ b/.github/workflows/documentation-ci-cd.yml
@@ -1,0 +1,53 @@
+# Copyright Jiaqi Liu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: Documentation CI/CD
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - master
+
+env:
+  USER: QubitPi
+  EMAIL: jack20220723@gmail.com
+
+jobs:
+  release:
+    name: Test & Release Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+      - name: Install dependencies
+        run: |
+          sudo apt-get install liberasurecode-dev
+          pip install swift
+          pip install -r requirements.txt -r doc/requirements.txt
+      - name: Build documentation
+        run: sphinx-build -b html doc/source doc/build/html
+      - name: Deploy documentation to GitHub Pages
+        if: github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: doc/build/html
+          user_name: ${{ env.USER }}
+          user_email: ${{ env.EMAIL }}

--- a/.github/workflows/documentation-ci-cd.yml
+++ b/.github/workflows/documentation-ci-cd.yml
@@ -37,10 +37,7 @@ jobs:
         with:
           python-version: "3.7"
       - name: Install dependencies
-        run: |
-          sudo apt-get install liberasurecode-dev
-          pip install swift
-          pip install -r requirements.txt -r doc/requirements.txt
+        run: pip install -r requirements.txt -r doc/requirements.txt
       - name: Build documentation
         run: sphinx-build -b html doc/source doc/build/html
       - name: Deploy documentation to GitHub Pages

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist/
 .tox
 *.egg
+.eggs/*
 *.egg-info
 *.py[co]
 .DS_Store

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,6 +27,8 @@ sys.path.insert(0, ROOT)
 
 # -- General configuration ----------------------------------------------------
 
+html_baseurl = '/openstack-python-swiftclient/'
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc',


### PR DESCRIPTION
Changelog
---------

### Added

- Added documentation CI/CD

  - Every pull request triggers documentation build test
  - Each `master` branch commit triggers the same build test above and, if successful, automatically deploys documentation to GitHub Pages

### Changed

- Added base path to sphinx config so that the doc resources loads properly on GitHub Pages

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation
